### PR TITLE
Update to serde_json and removal of  ⛅️ wrangler 3.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build wasm and publish dry run
         if: github.ref != 'refs/heads/main'
-        run: wrangler deploy --env test
+        run: CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }} wrangler deploy --env test
 
       - name: Build wasm and deploy
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,8 +81,8 @@ jobs:
 
       - name: Build wasm and publish dry run
         if: github.ref != 'refs/heads/main'
-        run: wrangler publish --name=id --dry-run=true
+        run: wrangler deploy --env test
 
-      - name: Build wasm and publish
+      - name: Build wasm and deploy
         if: github.ref == 'refs/heads/main'
-        run: CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }} wrangler publish --name=id
+        run: CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }} wrangler deploy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ cfg-if = "1.0.0"
 # When you change the version of workers, ensure the same version is set for
 # `WORKERS_RS_VERSION` in `wrangler.toml`, especially when dependabot does it
 worker = "0.0.17"
-# worker = { git = "https://github.com/cloudflare/workers-rs" }
-serde_json = "1.0.94"
-wasm-bindgen = "^0.2.84"
+serde_json = "1.0.96"
+wasm-bindgen = "=0.2.84"
 wasm-timer = "0.2.5"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,15 @@ kv_namespaces = [
     { binding = "id", id = "a2adaf2900e744a4b68f2dd248ceac52", preview_id = "79d9e5086960445abc089e9d753e0fb5" }
 ]
 
+[env.test]
+name = "test-id"
+routes = [
+    { pattern = "test-id.a1ecbr0wn.com", custom_domain = true }
+]
+kv_namespaces = [
+    { binding = "test-id", id = "79d9e5086960445abc089e9d753e0fb5" }
+]
+
 [vars]
 WORKERS_RS_VERSION = "0.0.17"
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,7 +14,7 @@ routes = [
     { pattern = "test-id.a1ecbr0wn.com", custom_domain = true }
 ]
 kv_namespaces = [
-    { binding = "test-id", id = "79d9e5086960445abc089e9d753e0fb5" }
+    { binding = "id", id = "79d9e5086960445abc089e9d753e0fb5" }
 ]
 
 [vars]


### PR DESCRIPTION
------------------
Running custom build: cargo install worker-build && worker-build --release Your worker has access to the following bindings:
- KV Namespaces:
  - id: a2adaf2900e744a4b68f2dd248ceac52
- Vars:
  - WORKERS_RS_VERSION: "0.0.17" Total Upload: 493.39 KiB / gzip: 231.10 KiB
Uploaded id (3.96 sec)
Published id (4.40 sec)
  id.a1ecbr0wn.com (custom domain)
Current Deployment ID: 0db1f0f2-bcf2-4b8a-aff6-436ee5f8c885 in favour of  ⛅️ wrangler 3.1.0 ------------------
Running custom build: cargo install worker-build && worker-build --release Your worker has access to the following bindings:
- KV Namespaces:
  - id: a2adaf2900e744a4b68f2dd248ceac52
- Vars:
  - WORKERS_RS_VERSION: "0.0.17" Total Upload: 493.39 KiB / gzip: 231.10 KiB
Uploaded id (3.00 sec)
Published id (3.57 sec)
  id.a1ecbr0wn.com (custom domain)
Current Deployment ID: 01194b1a-ae5d-4474-86a7-fbd38f20dbd6