### PR TITLE
ip defaulting to 2a06:98c0:3600::103' (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # ID: External IP Address Cloudflare Worker
 
-[![Crates.io](https://img.shields.io/crates/l/snapcraft)](https://github.com/a1ecbr0wn/id/blob/main/LICENSE) [![CI Build](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml/badge.svg)](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml) [![dependency status](https://deps.rs/repo/github/a1ecbr0wn/id/status.svg)](https://deps.rs/repo/github/a1ecbr0wn/id)
+[![Crates.io](https://img.shields.io/crates/l/snapcraft)](https://github.com/a1ecbr0wn/id/blob/main/LICENSE)
+[![CI Build](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml/badge.svg)](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml) [![dependency status](https://deps.rs/repo/github/a1ecbr0wn/id/status.svg)](https://deps.rs/repo/github/a1ecbr0wn/id)
 
 [Site: id.a1ecbr0wn.com](https://id.a1ecbr0wn.com)
 
-A simple ip address webservice using [Cloudflare's workers service](https://developers.cloudflare.com/workers/).  For use by [r53-ddns](https://r53-ddns.noser.net/).
+A simple ip address webservice using [Cloudflare's workers service](https://developers.cloudflare.com/workers/). For use by [r53-ddns](https://r53-ddns.noser.net/).
 
-This project uses the [`workers-rs`](https://github.com/cloudflare/workers-rs) crate to provide a simple rust WebAssembly binary that runs as a Cloudflare worker.  This is based off the standard [`worker-rust` template](https://github.com/cloudflare/templates/tree/main/worker-rust)
+This project uses the [`workers-rs`](https://github.com/cloudflare/workers-rs) crate to provide a simple rust WebAssembly binary that runs as a Cloudflare worker. This is based off the standard [`worker-rust` template](https://github.com/cloudflare/templates/tree/main/worker-rust)
 
 ## Install Wrangler
 
-``` sh
+```sh
 npm install -g wrangler
 ```
 
 ## Deployment
 
-The project is built and deployed to the [test environment](https://test-id.br0wn.workers.dev/) every time it is pushed via the `build.yml` github worflow, but it can also be deployed manually to the [dev environment](https://dev-id.a1ecbr0wn.workers.dev) if you have [`wrangler` installed](https://developers.cloudflare.com/workers/get-started/guide/#1-install-wrangler-workers-cli) by running:
+The project is built and deployed to the [test environment](https://test-id.br0wn.workers.dev/)
+every time it is pushed via the `build.yml` github worflow, but it can also be
+deployed manually to the [dev environment](https://dev-id.a1ecbr0wn.workers.dev)
+if you have [`wrangler` installed](https://developers.cloudflare.com/workers/get-started/guide/#1-install-wrangler-workers-cli)
+by running:
 
 ```sh
 wrangler deploy --env=test

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # ID: External IP Address Cloudflare Worker
 
 [![Crates.io](https://img.shields.io/crates/l/snapcraft)](https://github.com/a1ecbr0wn/id/blob/main/LICENSE)
-[![CI Build](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml/badge.svg)](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml) [![dependency status](https://deps.rs/repo/github/a1ecbr0wn/id/status.svg)](https://deps.rs/repo/github/a1ecbr0wn/id)
+[![CI Build](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml/badge.svg)](https://github.com/a1ecbr0wn/id/actions/workflows/build.yml)
+[![dependency status](https://deps.rs/repo/github/a1ecbr0wn/id/status.svg)](https://deps.rs/repo/github/a1ecbr0wn/id)
 
 [Site: id.a1ecbr0wn.com](https://id.a1ecbr0wn.com)
 
-A simple ip address webservice using [Cloudflare's workers service](https://developers.cloudflare.com/workers/). For use by [r53-ddns](https://r53-ddns.noser.net/).
+A simple ip address webservice using [Cloudflare's workers service](https://developers.cloudflare.com/workers/)
+. For use by [r53-ddns](https://r53-ddns.noser.net/).
 
-This project uses the [`workers-rs`](https://github.com/cloudflare/workers-rs) crate to provide a simple rust WebAssembly binary that runs as a Cloudflare worker. This is based off the standard [`worker-rust` template](https://github.com/cloudflare/templates/tree/main/worker-rust)
+This project uses the [`workers-rs`](https://github.com/cloudflare/workers-rs)
+crate to provide a simple rust WebAssembly binary that runs as a Cloudflare worker.
+This is based off the standard [`worker-rust` template](https://github.com/cloudflare/templates/tree/main/worker-rust)
 
 ## Install Wrangler
 
@@ -17,7 +21,7 @@ npm install -g wrangler
 
 ## Deployment
 
-The project is built and deployed to the [test environment](https://test-id.br0wn.workers.dev/)
+The project is built and deployed to the [test environment](https://test-id.a1ecbr0wn.workers.dev/)
 every time it is pushed via the `build.yml` github worflow, but it can also be
 deployed manually to the [dev environment](https://dev-id.a1ecbr0wn.workers.dev)
 if you have [`wrangler` installed](https://developers.cloudflare.com/workers/get-started/guide/#1-install-wrangler-workers-cli)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,6 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
                         more["http_protocol"] = json!(cf.http_protocol());
                         more["tls_version"] = json!(cf.tls_version());
                         more["tls_cipher"] = json!(cf.tls_cipher());
-                        if let Some() = cf {}
                         if let Some(asn) = cf.asn() {
                             more["asn"] = json!(asn);
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
                         more["http_protocol"] = json!(cf.http_protocol());
                         more["tls_version"] = json!(cf.tls_version());
                         more["tls_cipher"] = json!(cf.tls_cipher());
+                        if let Some() = cf {}
                         if let Some(asn) = cf.asn() {
                             more["asn"] = json!(asn);
                         }
@@ -208,7 +209,17 @@ where
     O: FnOnce(&str) -> Result<Response>,
     E: FnOnce(&str, u16) -> Result<Response>,
 {
-    if let Ok(Some(ip)) = req.headers().get("CF-Connecting-IP") {
+    if let Ok(Some(ip)) = req.headers().get("x-real-ip") {
+        if let Ok(store) = ctx.kv("id") {
+            if let Err(x) = rate::rate_control(store, &ip).await {
+                e(&x, 429)
+            } else {
+                o(&ip)
+            }
+        } else {
+            e("Service unavailable :(", 503)
+        }
+    } else if let Ok(Some(ip)) = req.headers().get("CF-Connecting-IP") {
         if let Ok(store) = ctx.kv("id") {
             if let Err(x) = rate::rate_control(store, &ip).await {
                 e(&x, 429)


### PR DESCRIPTION
According to the [docs](https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-connecting-ip):

In same-zone Worker subrequests, the value of `CF-Connecting-IP` reflects the value of `x-real-ip` (the client's IP). `x-real-ip` can be altered by the user in their Worker script.

In cross-zone subrequests from one Cloudflare zone to another Cloudflare zone, the `CF-Connecting-IP` value will be set to the Worker client IP address '2a06:98c0:3600::103' for security reasons.

When no Worker subrequest is triggered, `cf-connecting-ip` reflects the client's IP address and the `x-real-ip` header is stripped.